### PR TITLE
More enhancements to DJ Mode

### DIFF
--- a/Extensions/DJMode.js
+++ b/Extensions/DJMode.js
@@ -79,14 +79,17 @@ if (!DJSetting.enabled) {
 
 const playerControl = $(".player-controls-container");
 const extraControl = $(".extra-controls-container");
+const nowPlayingAddButton = $(".view-player .nowplaying-add-button");
 
 function showHideControl(hide) {
     if (hide) {
         playerControl.hide();
         extraControl.hide();
+		nowPlayingAddButton.hide();
     } else {
         playerControl.show();
         extraControl.show();
+		nowPlayingAddButton.show();
     }
 }
 
@@ -139,9 +142,9 @@ function findActiveIframeAndChangeButtonIntent() {
         })
 
         if (DJSetting.hideControls) {
-            doc.find('[data-ta-id="card-button-play"], [data-ta-id="card-button-add"], [data-ta-id="card-button-context-menu"], [data-ta-id="page-header-button-play"], [data-ta-id="page-header-button-more"], [data-ta-id="page-header-button-add"]').hide();
+            doc.find('[data-ta-id="card-button-play"], [data-ta-id="card-button-add"], [data-ta-id="card-button-context-menu"], [data-ta-id="page-header-button-play"], [data-ta-id="page-header-button-more"], [data-ta-id="page-header-button-add"], [data-button="add-recommendation"], [data-button="add"], [data-button="contextmenu"]').hide();
         } else {
-            doc.find('[data-ta-id="card-button-play"], [data-ta-id="card-button-add"], [data-ta-id="card-button-context-menu"], [data-ta-id="page-header-button-play"], [data-ta-id="page-header-button-more"], [data-ta-id="page-header-button-add"]').show();
+            doc.find('[data-ta-id="card-button-play"], [data-ta-id="card-button-add"], [data-ta-id="card-button-context-menu"], [data-ta-id="page-header-button-play"], [data-ta-id="page-header-button-more"], [data-ta-id="page-header-button-add"], [data-button="add-recommendation"], [data-button="add"], [data-button="contextmenu"]').show();
         }
         
     }

--- a/Extensions/DJMode.js
+++ b/Extensions/DJMode.js
@@ -181,6 +181,6 @@ function findActiveIframeAndChangeButtonIntent() {
 
 }
 
-setInterval(findActiveIframeAndChangeButtonIntent, 1000)
+setInterval(findActiveIframeAndChangeButtonIntent, 0)
 
 })()

--- a/Extensions/DJMode.js
+++ b/Extensions/DJMode.js
@@ -85,11 +85,11 @@ function showHideControl(hide) {
     if (hide) {
         playerControl.hide();
         extraControl.hide();
-		nowPlayingAddButton.hide();
+        nowPlayingAddButton.hide();
     } else {
         playerControl.show();
         extraControl.show();
-		nowPlayingAddButton.show();
+        nowPlayingAddButton.show();
     }
 }
 


### PR DESCRIPTION
**This needs some testing**. I've removed the save song button (+) from song names in playlists and the now playing bar at the bottom. This doesn't work on album pages though. I tried to remove the `.tl-save` column so there wasn't an extra space where the button used to be but I couldn't get it to work (see below)

![image](https://user-images.githubusercontent.com/38852913/39857896-49ca19b2-5478-11e8-9e86-dbba9a8bae67.png)

I also had to remove the 1 second delay because scrolling through playlists shows the button for a second before it hides. I haven't noticed any issues in performance.